### PR TITLE
fix passwords with specialchars

### DIFF
--- a/check_tr64_fritz
+++ b/check_tr64_fritz
@@ -236,7 +236,7 @@ esac
 queryResult=$(curl "https://${HOSTNAME}:${PORT}/upnp/control/${url}" \
 -k \
 -s \
--u ${USERNAME}:${PASSWORD} \
+-u "${USERNAME}":"${PASSWORD}" \
 --anyauth \
 -H "Content-Type: text/xml; charset='utf-8'" \
 -H "SOAPACTION: urn:dslforum-org:service:${service}:1#${action}" \

--- a/devel/fetch_tr64_data.sh
+++ b/devel/fetch_tr64_data.sh
@@ -53,7 +53,7 @@ echo ""
 queryResult=$(curl "https://${HOSTNAME}:${PORT}/upnp/control/${url}" \
 -k \
 -s \
--u ${USERNAME}:${PASSWORD} \
+-u "${USERNAME}:${PASSWORD}" \
 --anyauth \
 -H "Content-Type: text/xml; charset='utf-8'" \
 -H "SOAPACTION: urn:dslforum-org:service:${service}:1#${action}" \


### PR DESCRIPTION
"Double quote to prevent globbing and word splitting."
see https://github.com/koalaman/shellcheck/wiki/SC2086